### PR TITLE
Fix default zip path

### DIFF
--- a/index.js
+++ b/index.js
@@ -348,7 +348,7 @@ async function run(cfg) {
     }
 
     const uploadURL = r.upload_url;
-    const bundleFile = cfg.bundleFile || './build/build.zip';
+    const bundleFile = cfg.bundleFile || './build.zip';
 
     if (!cfg.bundleFile) {
       const excludedFiles = await glob.sync('./' + staticPath + '/**/*.txt');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vkontakte/vk-miniapps-deploy",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "description": "Deploy to VK Mini Apps hosting with one simple command",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
По умолчанию create-react-app кладет файлы в  build, поэтому класть zip архив в ./build/build.zip нельзя